### PR TITLE
Fix mathjax

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,5 +1,5 @@
 {
-    "plugins": ["mathjax","addcssjs"],
+    "plugins": ["mathjax@git+https://github.com/data-8/plugin-mathjax", "addcssjs"],
     "links": {
         "sidebar": {
             "Main Prob140 Site": "http://prob140.org/"


### PR DESCRIPTION
MathJax has changed their CDN URL (https://www.mathjax.org/cdn-shutting-down/) but Gitbook's MathJax plugin hasn't been updated to reflect that. This commit should fix the math rendering in the textbook by using Data8's fork of the plugin :) .