### PR TITLE
Use katex instead of mathjax

### DIFF
--- a/book.json
+++ b/book.json
@@ -1,21 +1,24 @@
 {
-    "plugins": ["addcssjs","collapsible-menu"],
+    "plugins": [
+        "katex@git+https://github.com/SamLau95/plugin-katex",
+        "addcssjs",
+        "collapsible-menu"
+    ],
     "links": {
         "sidebar": {
             "Main Prob140 Site": "http://prob140.org/"
         }
     },
-    "pluginsConfig": { 
-        "addcssjs": { 
-            "js": ["js/custom.js"],
+    "pluginsConfig": {
+        "addcssjs": {
+            "js": [],
             "css": []
-         },
+        },
         "theme-default": {
             "showLevel": false
         },
-         "fontsettings": {
+        "fontsettings": {
             "size": 1
-        }   
-     }
-     
+        }
+    }
 }

--- a/styles/website.css
+++ b/styles/website.css
@@ -3,6 +3,10 @@
 
 .katex {
   font-size: 1.1em;
+
+  /* Allow user to scroll to view the entire eqn if it's too long for screen */
+  width: 100%;
+  overflow: scroll;
 }
 
 .page-inner {

--- a/styles/website.css
+++ b/styles/website.css
@@ -3,6 +3,7 @@
 
 .katex {
   font-size: 1.1em;
+  line-height: 1;
 
   /* Allow user to scroll to view the entire eqn if it's too long for screen */
   width: 100%;

--- a/styles/website.css
+++ b/styles/website.css
@@ -1,6 +1,10 @@
 @import url('https://fonts.googleapis.com/css?family=Droid+Serif|Source+Sans+Pro:400,700');
 @import url('https://fonts.googleapis.com/css?family=PT+Sans');
 
+.katex {
+  font-size: 1.1em;
+}
+
 .page-inner {
     max-width: 1000px;
     margin: 1em auto;
@@ -661,10 +665,10 @@ cite, code, tt {
 .gsc-input::-webkit-input-placeholder {
   opacity:0;
 }
-.gsc-input::-moz-placeholder { 
+.gsc-input::-moz-placeholder {
   opacity:0;
 }
-.gsc-input:-ms-input-placeholder { 
+.gsc-input:-ms-input-placeholder {
   opacity:0;
 }
 .gsc-input:-moz-placeholder {

--- a/styles/website.css
+++ b/styles/website.css
@@ -6,7 +6,7 @@
 
   /* Allow user to scroll to view the entire eqn if it's too long for screen */
   width: 100%;
-  overflow: scroll;
+  overflow-x: scroll;
 }
 
 .page-inner {


### PR DESCRIPTION
I managed to get KaTeX to render in Gitbooks: https://github.com/SamLau95/plugin-katex

This fixes the mathjax initialization issue in a non-hacky way (no appending to the DOM, etc):

![prob140](https://user-images.githubusercontent.com/2468904/34914204-97201ed0-f8c2-11e7-8af5-d372ea5dd824.gif)

However, as the GIF above shows this breaks usages of `\mbox`. It looks like mbox isn't recommended (https://tex.stackexchange.com/questions/146909/what-does-mbox-do) and when I replace `\mbox` with `\text` the math renders just fine:

![screenshot 2018-01-14 00 40 49](https://user-images.githubusercontent.com/2468904/34914243-950b4cc2-f8c3-11e7-89fb-b83a59cf58f4.png)

Another change is that the `align*` environment needs to be wrapped in `$$` and replaced with `aligned` (this also renders in a notebook correctly). After doing that, math like this renders fine:

![screenshot 2018-01-14 00 44 31](https://user-images.githubusercontent.com/2468904/34914266-1782881e-f8c4-11e7-9d6b-7363c7d264be.png)

One perhaps easier thing to do is to just find and replace across all the notebooks for usage of `\mbox` and the `align*` environment during the notebook conversion step. What do you think?